### PR TITLE
RF: More than four categories get pushed to a second line on the top.

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -20,8 +20,3 @@
   excerpt: 
   image:
 
-- title: Articles
-  url: /articles
-  excerpt: "Dispatches from the fronts of science"
-  image: 
-


### PR DESCRIPTION
So - we can do without the link to the articles page, considering they're
at the bottom of the front page anyhow.