### PR TITLE
STY: use boxes for categories, to organize projects.

### DIFF
--- a/_packages/dipy.html
+++ b/_packages/dipy.html
@@ -4,6 +4,7 @@ name: "dipy"
 tag: "dipy"
 doc: "http://nipy.org/dipy/"
 github: "https://github.com/nipy/dipy"
-description: "Dipy is a free and open source software project focusing mainly on diffusion magnetic resonance imaging (dMRI) analysis."
+one-liner: "Focuses on diffusion magnetic resonance imaging (dMRI) analysis."
+description: "Dipy is a free and open source software project focusing on diffusion magnetic resonance imaging (dMRI) analysis."
 category: "diffusion-mri"
 ---

--- a/_packages/mindboggle.html
+++ b/_packages/mindboggle.html
@@ -4,7 +4,7 @@ name: "mindboggle"
 tag: "mindboggle"
 doc: "http://www.mindboggle.info/"
 github: "https://github.com/nipy/mindboggle"
-description: "The purpose of Mindboggle is to improve the accuracy, precision, and consistency of labeling and morphometry of brain imaging data, and to promote open science by making all data, software, and documentation freely and openly available."
+description: "Mindboggle improves the accuracy, precision, and consistency of labeling and morphometry of brain imaging data."
 category: "file-data-management"
 ---
 

--- a/_packages/mindboggle.html
+++ b/_packages/mindboggle.html
@@ -4,6 +4,7 @@ name: "mindboggle"
 tag: "mindboggle"
 doc: "http://www.mindboggle.info/"
 github: "https://github.com/nipy/mindboggle"
+one-liner: "Improves the accuracy, precision, and consistency of labeling &amp; morphometry of brain imaging data."
 description: "Mindboggle improves the accuracy, precision, and consistency of labeling and morphometry of brain imaging data."
 category: "file-data-management"
 ---

--- a/_packages/mne.html
+++ b/_packages/mne.html
@@ -4,7 +4,8 @@ name: "MNE"
 tag: "mne"
 doc: "http://martinos.org/mne/stable/index.html"
 github: "https://github.com/mne-tools/mne-python"
-description: "MNE is a software package for processing magnetoencephalography (MEG) and electroencephalography (EEG) data"
+one-liner: "Processes magnetoencephalography (MEG) and electroencephalography (EEG) data."
+description: "MNE is a software package for processing magnetoencephalography (MEG) and electroencephalography (EEG) data."
 category: "human-electrophysiology"
 ---
 

--- a/_packages/nibabel.html
+++ b/_packages/nibabel.html
@@ -4,7 +4,8 @@ name: "nibabel"
 tag: "nibabel"
 doc: "http://nipy.org/nibabel/"
 github: "https://github.com/nipy/nibabel"
-description: "Read / write access to some common neuroimaging file formats."
+one-liner: "Read / write common neuroimaging file formats."
+description: "Nibabel aims to provide read/write access to some common neuroimaging file formats."
 category: "file-data-management"
 ---
 

--- a/_packages/nilearn.html
+++ b/_packages/nilearn.html
@@ -4,6 +4,7 @@ name: "Nilearn"
 tag: "nilearn"
 doc: "http://nilearn.github.io"
 github: "https://github.com/nilearn/nilearn"
-description: "Nilearn is a Python module for fast and easy statistical learning on NeuroImaging data."
+one-liner: "Fast and easy statistical learning on neuroimaging data."
+description: "Nilearn is a Python module for fast and easy statistical learning on neuroimaging data."
 category: "machine-learning"
 ---

--- a/_packages/nipy.html
+++ b/_packages/nipy.html
@@ -4,6 +4,7 @@ name: "Nipy"
 tag: "nipy"
 doc: "http://nipy.org/nipy/"
 github: "https://github.com/nipy"
+one-liner: "Analysis of structural and functional neuroimaging data."
 description: "NIPY is not only the name of the Neuroimaging in Python community, but also a python project for analysis of structural and functional neuroimaging data."
 category: "functional-mri"
 ---

--- a/_packages/nipype.html
+++ b/_packages/nipype.html
@@ -4,6 +4,7 @@ name: "nipype"
 tag: "nipype"
 doc: "http://www.mit.edu/~satra/nipype-nightly/"
 github: "https://github.com/nipy/nipype"
+one-liner: "Provides a uniform interface to existing neuroimaging software."
 description: "Nipype provides a uniform interface to existing neuroimaging software and facilitates interaction between these packages within a single workflow."
 category: "analysis-pipeline-management"
 ---

--- a/_packages/nitime.html
+++ b/_packages/nitime.html
@@ -4,7 +4,8 @@ name: "Nitime"
 tag: "nitime"
 doc: "http://nipy.org/nitime/"
 github: "https://github.com/nipy/nitime"
-description: "Nitime is a library for time-series analysis of data from neuroscience experiments."
+one-liner: "Time-series analysis of neuroscience data."
+description: "Nitime is a library for time-series analysis of neuroscience data."
 category: "functional-mri"
 ---
 

--- a/_packages/pymvpa.html
+++ b/_packages/pymvpa.html
@@ -4,6 +4,7 @@ name: "PyMVPA"
 tag: "pymvpa"
 doc: "http://www.pymvpa.org/"
 github: "https://github.com/PyMVPA/PyMVPA"
+one-liner: "Eases statistical learning analyses of large neuroimaging datasets."
 description: "PyMVPA is a Python package intended to ease statistical learning analyses of large datasets."
 category: "machine-learning"
 ---

--- a/_packages/sdm.html
+++ b/_packages/sdm.html
@@ -4,6 +4,7 @@ name: "Scitran SDM"
 tag: "sdm"
 doc: "https://scitran.github.io/"
 github: "https://github.com/scitran/sdm"
+one-liner: "Delivers efficient and robust archiving, organization, and sharing of scientific data."
 description: "SciTran SDM delivers efficient and robust archiving, organization, and sharing of scientific data"
 category: "file-data-management"
 ---

--- a/index.html
+++ b/index.html
@@ -2,34 +2,41 @@
 layout: default
 ---
 
+<style>
+    h2 { margin-top:20px; margin-bottom:20px; }
+    .panel { margin-top: 15px; }
+    li { list-style-type: none; margin-bottom: 10px; }
+    a.package-name { text-decoration: underline }
+    .fa-github { color: #666; }
+    .fa-home { color: #333; margin-right: 5px; }
+</style>
+
 <h2 style="margin-top:20px; margin-bottom:20px">{{ site.url }}</h2>
 
 <p>Welcome to NIPY. The NIPY community is a community of practice devoted to the use of the Python programming language in the analysis of neuroimaging data. You can find us on <a href="https://github.com/nipy" target="_blank">github</a>, as well as <a href="http://neuroimaging.tumblr.com" target="_blank">social media</a>. We welcome <a href="{{ '/contribute.html' | prepend: site.baseurl">contributions</a> and welcome you to read about our <a href="{{ '/conduct.html' | prepend: site.baseurl }}">standards of conduct</a>, or <a href="{{ '/help.html' | prepend: site.baseurl }}">ask for help.</a> We develop the following projects:</p>
 
 <div class="panel-group" id="accordion">
-        {% for category in site.data.package-categories %}
-                <div class="panel panel-default" style="margin-top: 15px;">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a data-toggle="collapse" data-parent="#accordion" href="#pr{{ category.tag }}">{{ category.subtitle }}</a>
-                        </h4>
-                    </div>
-                    <div id="pr{{ category.tag }}" class="panel-collapse collapse in">
-                        <div class="panel-body">
-            {% for package in site.packages %}
-                {% if package.category == category.tag %}
-                            <li style="list-style-type: none; margin-bottom: 10px;">
-                            <a href="{{ package.github }}" target="_blank"><i style="color:#666;" class="fa fa-github"> </i></a>
-                            <a href="{{ package.doc }}" target="_blank"><i style="color:#333;margin-right:5px" class="fa fa-home"></i></a>
-                            <a href="{{ package.url | prepend: site.baseurl }}" style="text-decoration: underline">
-                                {{ package.name }}
-                            </a>
-                             - {{ package.description }}
-                            </li>
-                {% endif %}
-             {% endfor %}
-                        </div>
-                    </div>
+    {% for category in site.data.package-categories %}
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">
+                    <a data-toggle="collapse" data-parent="#accordion" href="#pr{{ category.tag }}">{{ category.subtitle }}</a>
+                </h4>
+            </div>
+            <div id="pr{{ category.tag }}" class="panel-collapse collapse in">
+                <div class="panel-body">
+        {% for package in site.packages %}
+            {% if package.category == category.tag %}
+                    <li>
+                        <a href="{{ package.github }}" target="_blank"><i class="fa fa-github"> </i></a>
+                        <a href="{{ package.doc }}" target="_blank"><i class="fa fa-home"></i></a>
+                        <a class="package-name" href="{{ package.url | prepend: site.baseurl }}">{{ package.name }}</a>
+                         - {{ package.description }}
+                    </li>
+            {% endif %}
+         {% endfor %}
                 </div>
-       {% endfor %}
+            </div>
+        </div>
+   {% endfor %}
 </div>

--- a/index.html
+++ b/index.html
@@ -8,26 +8,28 @@ layout: default
 
 <div class="panel-group" id="accordion">
         {% for category in site.data.package-categories %}
-            {% for package in site.packages %}
-                {% if package.category == category.tag %}
-                <div class="panel panel-default">
+                <div class="panel panel-default" style="margin-top: 15px;">
                     <div class="panel-heading">
                         <h4 class="panel-title">
-                            <a data-toggle="collapse" data-parent="#accordion" href="#pr{{ package.tag }}">{{ package.name }}</a>
-                            <a href="{{ package.github }}" target="_blank"><i style="color:#666;float:right;" class="fa fa-github"> </i></a>
-                            <a href="{{ package.doc }}" target="_blank"><i style="color:#333;float:right; margin-right:5px" class="fa fa-home"></i></a>
+                            <a data-toggle="collapse" data-parent="#accordion" href="#pr{{ category.tag }}">{{ category.subtitle }}</a>
                         </h4>
                     </div>
-                    <div id="pr{{ package.tag }}" class="panel-collapse collapse in">
+                    <div id="pr{{ category.tag }}" class="panel-collapse collapse in">
                         <div class="panel-body">
-                        <p>{{ package.description }}</p>
-                        <a href="{{ package.url | prepend: site.baseurl }}">
-                            <span style="float:right">learn more</span>
-                        </a>
+            {% for package in site.packages %}
+                {% if package.category == category.tag %}
+                            <li style="list-style-type: none; margin-bottom: 10px;">
+                            <a href="{{ package.github }}" target="_blank"><i style="color:#666;" class="fa fa-github"> </i></a>
+                            <a href="{{ package.doc }}" target="_blank"><i style="color:#333;margin-right:5px" class="fa fa-home"></i></a>
+                            <a href="{{ package.url | prepend: site.baseurl }}" style="text-decoration: underline">
+                                {{ package.name }}
+                            </a>
+                             - {{ package.description }}
+                            </li>
+                {% endif %}
+             {% endfor %}
                         </div>
                     </div>
                 </div>
-                {% endif %}
-             {% endfor %}
        {% endfor %}
 </div>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ layout: default
                         <a href="{{ package.github }}" target="_blank"><i class="fa fa-github"> </i></a>
                         <a href="{{ package.doc }}" target="_blank"><i class="fa fa-home"></i></a>
                         <a class="package-name" href="{{ package.url | prepend: site.baseurl }}">{{ package.name }}</a>
-                         - {{ package.description }}
+                         - {% if package.one-liner %}{{ package.one-liner }}{% else %}{{ package.description }}{% endif %}
                     </li>
             {% endif %}
          {% endfor %}


### PR DESCRIPTION
This PR addresses issue #18 (click behavior on box header) and #19 (ordering of projects seems arbitrary)

The current homepage layout gives a *lot* of space to each project, without showing the overall organization across projects. This simple PR "boxes" projects by category.

I don't think this is the best layout, but I do think it's an improvement for users looking to scan what is available in nipy.

![image](https://cloud.githubusercontent.com/assets/4072455/11448571/db942174-950f-11e5-8a12-5f93b1766f19.png)
