### PR TITLE
Add seo tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,14 @@ paginate_path: /page:num/
 version: "1.1.0"
 googleanalytics: "UA-69411900-1"
 
+# SEO
+logo: /img/nipy.png
+authorTwitter: 'nipyorg'
+gems:
+  - jekyll-seo-tag
+  - jekyll-paginate
+
+
 # Options
 reverse: true
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,8 +18,8 @@
        <link rel="stylesheet" href="{{ '/css/bootstrap.min.css' | prepend: site.baseurl }}">
        <link rel="stylesheet" href="{{ '/css/main.css' | prepend: site.baseurl }}">
        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-	<link href='https://fonts.googleapis.com/css?family=Roboto:300' rel='stylesheet' type='text/css'>
-
+       <link href='https://fonts.googleapis.com/css?family=Roboto:300' rel='stylesheet' type='text/css'>
+       {% seo %}
 
 	<!-- RSS -->
 	<link href="/atom.xml" type="application/atom+xml" rel="alternate" title="ATOM Feed" />

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,7 @@ general:
 test:
   override:
     - gem install jekyll-paginate
+    - gem install jekyll-seo-tag
     - chmod u+x circle_urls.sh
     - bash circle_urls.sh
     - rm -rf vendor


### PR DESCRIPTION
This PR will add the "jekyll-seo-tag" plugin, which adds a tag to the header to render meta data and a json-ld object into each header, (which they say) is good for Google search. This will close #35, and is a fix to my first PR to have rebased with master (oups). For example, here is the Dipy page:

![image](https://cloud.githubusercontent.com/assets/814322/15227255/1f90cda6-183b-11e6-9645-51071127705e.png)

here is the base page:

![image](https://cloud.githubusercontent.com/assets/814322/15227278/3fe1c948-183b-11e6-8159-f7a5b1ce2d56.png)

It might make a difference, it might not, the plugin was recently [featured on the github blog](https://github.com/blog/2162-better-discoverability-for-github-pages-sites), and I thought wouldn't hurt to add.