### PR TITLE
adding Computational Anatomy as a category, for mindboggle and dipy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.0'
+ruby '2.4.1'
 
 gem 'jekyll'
 gem 'html-proofer'

--- a/_data/package-categories.yml
+++ b/_data/package-categories.yml
@@ -21,4 +21,4 @@
   count: 7
 - subtitle: "Data Visualisation"
   tag: "data-visualisation"
-  count: 7
+  count: 8

--- a/_data/package-categories.yml
+++ b/_data/package-categories.yml
@@ -1,8 +1,8 @@
 - subtitle: "Analysis Pipeline Management"
   tag: "analysis-pipeline-management"
   count: 1
-- subtitle: "Anatomical MRI"
-  tag: "anatomical-mri"
+- subtitle: "Computational Anatomy"
+  tag: "computational-anatomy"
   count: 2
 - subtitle: "File I/O and Data Management"
   tag: "file-data-management"

--- a/_data/package-categories.yml
+++ b/_data/package-categories.yml
@@ -16,6 +16,9 @@
 - subtitle: "Human Electrophysiology"
   tag: "human-electrophysiology"
   count: 6
+- subtitle: "Data Curation"
+  tag: "data-curation"
+  count: 7
 - subtitle: "Data Visualisation"
   tag: "data-visualisation"
-  count: 1
+  count: 7

--- a/_data/package-categories.yml
+++ b/_data/package-categories.yml
@@ -1,8 +1,8 @@
 - subtitle: "Analysis Pipeline Management"
   tag: "analysis-pipeline-management"
   count: 1
-- subtitle: "Diffusion MRI"
-  tag: "diffusion-mri"
+- subtitle: "Anatomical MRI"
+  tag: "anatomical-mri"
   count: 2
 - subtitle: "File I/O and Data Management"
   tag: "file-data-management"
@@ -16,9 +16,6 @@
 - subtitle: "Human Electrophysiology"
   tag: "human-electrophysiology"
   count: 6
-- subtitle: "Data Curation"
-  tag: "data-curation"
-  count: 7
 - subtitle: "Data Visualisation"
   tag: "data-visualisation"
-  count: 8
+  count: 7

--- a/_packages/dipy.html
+++ b/_packages/dipy.html
@@ -6,5 +6,5 @@ doc: "http://nipy.org/dipy/"
 github: "https://github.com/nipy/dipy"
 one-liner: "Focuses on diffusion magnetic resonance imaging (dMRI) analysis."
 description: "Dipy is a free and open source software project focusing on diffusion magnetic resonance imaging (dMRI) analysis."
-category: "anatomical-mri"
+category: "computational-anatomy"
 ---

--- a/_packages/dipy.html
+++ b/_packages/dipy.html
@@ -6,5 +6,5 @@ doc: "http://nipy.org/dipy/"
 github: "https://github.com/nipy/dipy"
 one-liner: "Focuses on diffusion magnetic resonance imaging (dMRI) analysis."
 description: "Dipy is a free and open source software project focusing on diffusion magnetic resonance imaging (dMRI) analysis."
-category: "diffusion-mri"
+category: "anatomical-mri"
 ---

--- a/_packages/mindboggle.html
+++ b/_packages/mindboggle.html
@@ -6,6 +6,6 @@ doc: "http://www.mindboggle.info/"
 github: "https://github.com/nipy/mindboggle"
 one-liner: "Improves the accuracy, precision, and consistency of labeling &amp; morphometry of brain imaging data."
 description: "Mindboggle improves the accuracy, precision, and consistency of labeling and morphometry of brain imaging data."
-category: "file-data-management"
+category: "data-curation"
 ---
 

--- a/_packages/mindboggle.html
+++ b/_packages/mindboggle.html
@@ -6,6 +6,5 @@ doc: "http://www.mindboggle.info/"
 github: "https://github.com/nipy/mindboggle"
 one-liner: "Improves the accuracy, precision, and consistency of labeling &amp; morphometry of brain imaging data."
 description: "Mindboggle improves the accuracy, precision, and consistency of labeling and morphometry of brain imaging data."
-category: "anatomical-mri"
+category: "computational-anatomy"
 ---
-

--- a/_packages/mindboggle.html
+++ b/_packages/mindboggle.html
@@ -6,6 +6,6 @@ doc: "http://www.mindboggle.info/"
 github: "https://github.com/nipy/mindboggle"
 one-liner: "Improves the accuracy, precision, and consistency of labeling &amp; morphometry of brain imaging data."
 description: "Mindboggle improves the accuracy, precision, and consistency of labeling and morphometry of brain imaging data."
-category: "data-curation"
+category: "anatomical-mri"
 ---
 


### PR DESCRIPTION
This will create a new category, Data Curation and Annotation, and move mind boggle to it, as a suggested fix to #47. @satra your feedback appreciated here!