### PR TITLE
Testing ruby 2.5.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.5.3'
+ruby '2.5.5'
 
 gem 'jekyll'
 gem 'html-proofer'


### PR DESCRIPTION
The build fail in #55 is a result of a version difference, let's test 2.5.5.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>