### PR TITLE
DOC: Update the DIPY gitter room URL

### DIFF
--- a/help.html
+++ b/help.html
@@ -22,4 +22,4 @@ layout: default
 
 <h2>Github issues</h2>
 
-<p>Most of the projects have an issues page on which you are (very) welcome to report about problems that you have encountered using the software. For example, for issues related to the Dipy software library, please go here: <a href="https://github.com/dipy/dipy/issues" target="_blank">https://github.com/dipy/dipy/issues</a>. More informal conversations can be struck on the gitter pages of the projects (e.g. <a href="https://gitter.im/nipy/dipy" target="_blank">https://gitter.im/nipy/dipy)</a></p>.
+<p>Most of the projects have an issues page on which you are (very) welcome to report about problems that you have encountered using the software. For example, for issues related to the Dipy software library, please go here: <a href="https://github.com/dipy/dipy/issues" target="_blank">https://github.com/dipy/dipy/issues</a>. More informal conversations can be struck on the gitter pages of the projects (e.g. <a href="https://gitter.im/dipy/dipy" target="_blank">https://gitter.im/dipy/dipy)</a></p>.


### PR DESCRIPTION
Update the DIPY gitter room URL.

Follows the DIPY PR:
https://github.com/dipy/dipy/pull/2171