### PR TITLE
Bumping sub version to 2.5.8 from 2.5.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.5.7'
+ruby '2.5.8'
 
 gem 'jekyll'
 gem 'html-proofer'


### PR DESCRIPTION
We are using the [circleci/ruby](https://hub.docker.com/r/circleci/ruby) docker base, specifically the 2.5 tag. This means that if there is a sub version change (as there was here, .7 to .8) the CI will fail. I think the failure is suitable to alert us about the base update, and that way we don't hard code a version into the CI that possibly needs a security fix, etc. If this build is successful then that is sufficient for this to merge.

Signed-off-by: vsoch <vsochat@stanford.edu>