### PR TITLE
adding status token to fix badge error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ nipy.org is built with a custom theme created for Jekyll.
 - [site](http://www.nipy.org)
 - preview changes with [continuous integration](https://circleci.com/gh/nipy/nipy.github.com/tree/master)
 
-[![Circle CI](https://circleci.com/gh/nipy/nipy.github.com.svg?style=svg)](https://circleci.com/gh/nipy/nipy.github.com)
+[![Circle CI](https://circleci.com/gh/nipy/nipy.github.com.svg?style=svg&circle-token=252deb3d4cecabeb53ae04acff325065fc72598d)](https://circleci.com/gh/nipy/nipy.github.com)
 [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 
 ###### Install Jekyll and RubyGems


### PR DESCRIPTION
Note that the token is scoped to "status" so I don't think it can be used maliciously (and is intended for putting in a repo). Thoughts? I had thought this only was relevant for private repos, but it seems to be the case here. This will close #63 

Signed-off-by: vsoch <vsochat@stanford.edu>